### PR TITLE
Added event weight support

### DIFF
--- a/PU14/EventMixer.cc
+++ b/PU14/EventMixer.cc
@@ -45,16 +45,18 @@ EventMixer::EventMixer(CmdLine * cmdline) : _cmdline(cmdline) {
 //----------------------------------------------------------------------
 bool EventMixer::next_event() {
   _particles.resize(0);
+  _hard_event_weight = 1;
+  _pu_event_weight = 1;
   
   // first get the hard event
-  if (! _hard->append_next_event(_particles,0)) return false;
+  if (! _hard->append_next_event(_particles,_hard_event_weight,0)) return false;
 
   unsigned hard_size = _particles.size();
 
   // add pileup if available
   if (_pileup.get()){
     for (int i = 1; i <= _npu; i++) {
-      if (! _pileup->append_next_event(_particles,i)) return false;
+      if (! _pileup->append_next_event(_particles,_pu_event_weight,i)) return false;
     }
   }
 

--- a/PU14/EventMixer.hh
+++ b/PU14/EventMixer.hh
@@ -38,6 +38,11 @@ public:
   /// that was read in
   const std::vector<fastjet::PseudoJet> & particles() const {return _particles;}
 
+  /// returns the current event weight
+  double weight() {return _hard_event_weight * _pu_event_weight;}
+  double pu_weight() {return _pu_event_weight;}
+  double hard_weight() {return _hard_event_weight;}
+
   /// returns the number of pileup events generated in the last mixed event 
   int npu() const {return _npu;}
 
@@ -67,6 +72,7 @@ private:
   bool _massless;
 
   std::vector<fastjet::PseudoJet> _particles;
+  double _hard_event_weight, _pu_event_weight;
 };
 
 #endif  // __EVENTMIXER_HH__

--- a/PU14/EventSource.hh
+++ b/PU14/EventSource.hh
@@ -25,7 +25,7 @@ public:
   /// appends the particles from the next event that is read onto the 
   /// particles vector.
   bool append_next_event(std::vector<fastjet::PseudoJet> & particles,
-                         int vertex_number = 0);
+        double &event_weight, int vertex_number = 0);
 
 private:
   std::istream * _stream;

--- a/runFromFile.cc
+++ b/runFromFile.cc
@@ -62,14 +62,19 @@ int main (int argc, char ** argv) {
   // loop over events
   int iev = 0;
   unsigned int entryDiv = (nEvent > 200) ? nEvent / 200 : 1;
-  while ( mixer.next_event() && iev < nEvent ) {
+  while ( mixer.next_event() && iev < nEvent )
+  {
     // increment event number    
     iev++;
 
     Bar.Update(iev);
     Bar.PrintWithMod(entryDiv);
 
-    std::vector<fastjet::PseudoJet> particlesMerged = mixer.particles() ;
+    std::vector<fastjet::PseudoJet> particlesMerged = mixer.particles();
+
+    std::vector<double> eventWeight;
+    eventWeight.push_back(mixer.hard_weight());
+    eventWeight.push_back(mixer.pu_weight());
 
     // cluster hard event only
     std::vector<fastjet::PseudoJet> particlesBkg, particlesSig;
@@ -198,6 +203,7 @@ int main (int argc, char ** argv) {
     trw.addCollection("csRho",         rho);
     trw.addCollection("csRhom",        rhom);
     trw.addCollection("skPtThreshold", skPtThreshold);
+    trw.addCollection("eventWeight",   eventWeight);
 
     trw.addCollection("unsubJet",      jetCollectionMerged);
         


### PR DESCRIPTION
New functions:
EventMixer::hard_weight(): gets hard event weight
EventMixer::pu_weight(): gets PU event weight
EventMixer::weight(): returns product of two weights

The weights default to 1 if it is not present in the pu14 file


