### PR TITLE
Safety code for rho and rhom

### DIFF
--- a/include/csSubtractor.hh
+++ b/include/csSubtractor.hh
@@ -97,6 +97,9 @@ public :
 
     rho_ = bkgd_estimator.rho();
     rhom_ = bkgd_estimator.rho_m();
+    
+    if(rho_ < 0)    rho_ = 0;
+    if(rhom_ < 0)   rhom_ = 0;
 
     subtractor_.set_background_estimator(&bkgd_estimator);
     subtractor_.set_common_bge_for_rho_and_rhom(true);

--- a/runFromFile.cc
+++ b/runFromFile.cc
@@ -107,9 +107,6 @@ int main (int argc, char ** argv) {
     std::vector<double> rho;    rho.push_back(csSub.getRho());
     std::vector<double> rhom;   rhom.push_back(csSub.getRhoM());
 
-    if(rho[0] < 0)    rho[0] = 0;
-    if(rhom[0] < 0)   rhom[0] = 0;
-
     //run full event constituent subtraction on mixed (hard+UE) event
     csSubtractorFullEvent csSubGlobal(1., R, 0.005,ghostRapMax);
     csSubGlobal.setRho(rho[0]);

--- a/runFromFile.cc
+++ b/runFromFile.cc
@@ -107,6 +107,9 @@ int main (int argc, char ** argv) {
     std::vector<double> rho;    rho.push_back(csSub.getRho());
     std::vector<double> rhom;   rhom.push_back(csSub.getRhoM());
 
+    if(rho[0] < 0)    rho[0] = 0;
+    if(rhom[0] < 0)   rhom[0] = 0;
+
     //run full event constituent subtraction on mixed (hard+UE) event
     csSubtractorFullEvent csSubGlobal(1., R, 0.005,ghostRapMax);
     csSubGlobal.setRho(rho[0]);


### PR DESCRIPTION
For some events rho and rho_m gets below zero due to rounding.  Added safety code to prevent CS from killing the whole program.