### PR TITLE
Unify branch names in the example file

### DIFF
--- a/include/softDropGroomer.hh
+++ b/include/softDropGroomer.hh
@@ -40,7 +40,7 @@ public :
   void setInputJets(std::vector<fastjet::PseudoJet> v);
   std::vector<fastjet::PseudoJet> getGroomedJets() const;
   std::vector<double> getZgs() const;
-  std::vector<int> getNDroppedBranches() const;
+  std::vector<int> getNDroppedSubjets() const;
   std::vector<double> getDR12() const;
   std::vector<fastjet::PseudoJet> doGrooming(jetCollection &c);
   std::vector<fastjet::PseudoJet> doGrooming(std::vector<fastjet::PseudoJet> v);
@@ -82,7 +82,7 @@ std::vector<double> softDropGroomer::getZgs() const
    return zg_;
 }
 
-std::vector<int> softDropGroomer::getNDroppedBranches() const
+std::vector<int> softDropGroomer::getNDroppedSubjets() const
 {
    return drBranches_;
 }

--- a/runFromFile.cc
+++ b/runFromFile.cc
@@ -165,16 +165,16 @@ int main (int argc, char ** argv) {
     //SoftDrop grooming classic for CS jets (zcut=0.1, beta=0)
     softDropGroomer sdgCS(0.1, 0.0, R);
     jetCollection jetCollectionCSSD(sdgCS.doGrooming(jetCollectionCS));
-    jetCollectionCSSD.addVector("zgCSSD",    sdgCS.getZgs());
-    jetCollectionCSSD.addVector("ndropCSSD", sdgCS.getNDroppedBranches());
-    jetCollectionCSSD.addVector("dr12CSSD",  sdgCS.getDR12());
+    jetCollectionCSSD.addVector("csJetSDzg",    sdgCS.getZgs());
+    jetCollectionCSSD.addVector("csJetSDndrop", sdgCS.getNDroppedSubjets());
+    jetCollectionCSSD.addVector("csJetSDdr12",  sdgCS.getDR12());
 
     //SoftDrop grooming classic for signal jets (zcut=0.1, beta=0)
     softDropGroomer sdgSig(0.1, 0.0, R);
     jetCollection jetCollectionSigSD(sdgSig.doGrooming(jetCollectionSig));
-    jetCollectionSigSD.addVector("zgSigSD",    sdgSig.getZgs());
-    jetCollectionSigSD.addVector("ndropSigSD", sdgSig.getNDroppedBranches());
-    jetCollectionSigSD.addVector("dr12SigSD",  sdgSig.getDR12());
+    jetCollectionSigSD.addVector("sigJetSDZg",    sdgSig.getZgs());
+    jetCollectionSigSD.addVector("sigJetSDndrop", sdgSig.getNDroppedSubjets());
+    jetCollectionSigSD.addVector("sigJetSDdr12",  sdgSig.getDR12());
     
     //match the CS jets to signal jets
     jetMatcher jmCS(R);

--- a/runtest.cc
+++ b/runtest.cc
@@ -147,7 +147,7 @@ int main (int argc, char ** argv)
     softDropGroomer sdgCS(0.1, 0.0, R);   //zcut=0.1 beta=0
     jetCollection jetCollectionCSSD(sdgCS.doGrooming(jetCollectionCS));
     jetCollectionCSSD.addVector("csJetSDZg",    sdgCS.getZgs());
-    jetCollectionCSSD.addVector("csJetSDNdrop", sdgCS.getNDroppedBranches());
+    jetCollectionCSSD.addVector("csJetSDNdrop", sdgCS.getNDroppedSubjets());
 
 
     //SoftDrop emission counting for CS jets
@@ -175,7 +175,7 @@ int main (int argc, char ** argv)
     softDropGroomer sdgSig(0.1, 0.0, R);   //zcut=0.1 beta=0
     jetCollection jetCollectionSigSD(sdgSig.doGrooming(jetCollectionSig));
     jetCollectionSigSD.addVector("sigJetSDZg",    sdgSig.getZgs());
-    jetCollectionSigSD.addVector("sigJetSDNdrop", sdgSig.getNDroppedBranches());
+    jetCollectionSigSD.addVector("sigJetSDNdrop", sdgSig.getNDroppedSubjets());
 
     
     //SoftDrop emission counting for signal jets


### PR DESCRIPTION
Now it's both sigJetSDxxx and csJetSDxxx.  It's less confusing this way.